### PR TITLE
Export data in blob URL instead of data URL

### DIFF
--- a/scripts/engine/Editor.js
+++ b/scripts/engine/Editor.js
@@ -180,7 +180,14 @@ Editor.create = function(){
 		exportModel.id = "save_changes";
 		exportModel.innerHTML = "<span style='font-size:25px; line-height:35px; font-family:monospace'>{}</span>export model";
 		exportModel.onclick = function(){
-			window.open("data:text/json;charset=utf-8,"+JSON.stringify(Model.data));
+			var blob = new Blob([JSON.stringify(Model.data)], { type: "text/json" });
+			var objectURL = URL.createObjectURL(blob);
+			var newWindow = window.open(objectURL);
+			function cleanUpCallback() {
+				URL.revokeObjectURL(objectURL);
+				newWindow.removeEventListener("load", cleanUpCallback, true);
+			}
+			newWindow.addEventListener("load", cleanUpCallback, true);
 		};
 		Editor.dom.appendChild(exportModel);
 


### PR DESCRIPTION
Chromium no longer allows opening data URLs in the top frame, Microsoft Edge never allowed it, which interferes with exporting the data of models.

This PR instead uses blob URLs to achieve the same result. Blob URLs should work in all major and recent browsers according to [Can I use](https://caniuse.com/?search=blob), but I have only had the chance to test it in Microsoft Edge, Chrome, and Firefox.